### PR TITLE
Allow bundler to choose right build

### DIFF
--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -92,6 +92,6 @@ module.exports = {
          *     },
          * },
          */
-        'autonumeric/dist/autoNumeric.min': 'AutoNumeric',
+        autonumeric: 'AutoNumeric',
     },
 };

--- a/dist/vue-autonumeric.js
+++ b/dist/vue-autonumeric.js
@@ -1,6 +1,6 @@
 /**
  * vue-autonumeric v1.2.6 (https://github.com/autoNumeric/vue-autoNumeric)
- * © 2018 Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>
+ * © 2019 Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>
  * Released under the MIT License.
  */
 (function webpackUniversalModuleDefinition(root, factory) {
@@ -306,9 +306,9 @@ var _assign = __webpack_require__(16);
 
 var _assign2 = _interopRequireDefault(_assign);
 
-var _autoNumeric = __webpack_require__(43);
+var _autonumeric = __webpack_require__(43);
 
-var _autoNumeric2 = _interopRequireDefault(_autoNumeric);
+var _autonumeric2 = _interopRequireDefault(_autonumeric);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -400,7 +400,7 @@ exports.default = {
         this.hasContentEditable = !this.initialOptions.readOnly;
     },
     mounted: function mounted() {
-        this.anElement = new _autoNumeric2.default(this.$refs.autoNumericElement, this.initialOptions);
+        this.anElement = new _autonumeric2.default(this.$refs.autoNumericElement, this.initialOptions);
         if (this.value !== null && this.value !== '') {
             this.anElement.set(this.value);
 
@@ -427,7 +427,7 @@ exports.default = {
         manageOptionElement: function manageOptionElement(optionElement) {
             var options = void 0;
             if (typeof optionElement === 'string' || optionElement instanceof String) {
-                options = _autoNumeric2.default.getPredefinedOptions()[optionElement];
+                options = _autonumeric2.default.getPredefinedOptions()[optionElement];
                 if (options === void 0 || options === null) {
                     console.warn('The given pre-defined options [' + optionElement + '] is not recognized by AutoNumeric.\nSwitching back to the default options.');
                     options = defaultOptions;
@@ -449,9 +449,9 @@ exports.default = {
 
                 var optionsToUse = void 0;
                 if (Array.isArray(newValue.options)) {
-                    optionsToUse = _autoNumeric2.default.mergeOptions(newValue.options);
+                    optionsToUse = _autonumeric2.default.mergeOptions(newValue.options);
                 } else {
-                    optionsToUse = _autoNumeric2.default._getOptionObject(newValue.options);
+                    optionsToUse = _autonumeric2.default._getOptionObject(newValue.options);
                 }
 
                 this.anElement.update(optionsToUse);

--- a/src/components/VueAutonumeric.vue
+++ b/src/components/VueAutonumeric.vue
@@ -38,7 +38,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 -->
 
 <script type="text/babel">
-    import AutoNumeric from 'autonumeric/dist/autoNumeric.min';
+    import AutoNumeric from 'autonumeric';
 
     // Custom default autoNumeric option can be set here to override the default autoNumeric ones
     const defaultOptions = {};


### PR DESCRIPTION
I have changed the direct import of bundled minified version to generic `'autonumeric'`.

So bundlers like webpack will be able to choose the right version depends on the package.json fields: main, browser, module.
This can lead to smaller bundle size for ES6 environment.

Notes:
- `dist/vue-autonumeric.js` is not really changed, only variable naming was changed by webpack during build, if you want I can revert it
- There is a note in the webpack.base.js about the need of webpack alias for ES6 module setup, but it works fine for me without alias, maybe it is outdated now and was required only for older versions of webpack?