### PR TITLE
Add typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lintfix": "eslint --fix --ext .js,.vue src examples-src build"
   },
   "main": "dist/vue-autonumeric.min.js",
+  "typings": "types/index.d.ts",
   "readmeFilename": "README.md",
   "keywords": [
     "autonumeric",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,9 @@
+import Vue from 'vue';
+
+export default class VueAutonumeric extends Vue {
+    public value: number | null | string;
+    public options: object | string | object[] | string[];
+    public resetOnOptions: boolean;
+    public placeholder: string;
+    public tag: string;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,11 @@
-import Vue from 'vue';
+declare module 'vue-autonumeric' {
+    import Vue from 'vue';
 
-export default class VueAutonumeric extends Vue {
-    public value: number | null | string;
-    public options: object | string | object[] | string[];
-    public resetOnOptions: boolean;
-    public placeholder: string;
-    public tag: string;
+    export default class VueAutonumeric extends Vue {
+        public value: number | null | string;
+        public options: object | string | object[] | string[];
+        public resetOnOptions: boolean;
+        public placeholder: string;
+        public tag: string;
+    }
 }


### PR DESCRIPTION
Adds typescript definitions for vue-autoNumeric component.
Also referenced them in package.json so they will automatically used when this package is added to an typescript project.